### PR TITLE
Add reset! command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ The maximum number of times the block will be yielded looking for a unique objec
 Unique.max_tries= 10
 ```
 
+## Cleanup
+
+`Unique.reset!` will clear previous objects and allow them to be used. This is
+useful in your test suites `before` blocks.
+
+### Example
+
+```ruby
+1.9.3-p551 :001 > Unique.next!{ rand(1) }
+ => 0
+1.9.3-p551 :002 > Unique.next!{ rand(1) }
+Unique::NoUniqueObjects: An unused, unique object could not be found in 4096 tries (["(irb)", 2])
+  from /home/devbox/code/unique/lib/unique.rb:22:in `block in next!'
+  from /home/devbox/code/unique/lib/unique.rb:20:in `loop'
+  from /home/devbox/code/unique/lib/unique.rb:20:in `next!'
+  from (irb):6
+  from /home/devbox/.rvm/rubies/ruby-1.9.3-p551/bin/irb:12:in `<main>'
+1.9.3-p551 :003 > Unique.reset!
+ => []
+1.9.3-p551 :004 > Unique.next!{ rand(1) }
+ => 0
+```
+
 ## Is it any good?
 
 [Yes](https://news.ycombinator.com/item?id=3067434)

--- a/lib/unique.rb
+++ b/lib/unique.rb
@@ -26,5 +26,9 @@ module ::Unique
       end
     }
   end
+
+  def self.reset!
+    @@instances = Array.new
+  end
 end
 require_relative 'unique/version'

--- a/spec/unique/unique_spec.rb
+++ b/spec/unique/unique_spec.rb
@@ -3,8 +3,18 @@
 require 'spec_helper'
 
 describe Unique do
+  context '.reset!' do
+    before(:each) { Unique.next! { rand(500) } }
+
+    it "clears @@instances" do
+      Unique.reset!
+
+      expect(Unique.class_variable_get(:@@instances)).to eq([])
+    end
+  end
+
   context ".next!" do
-    before(:each) { Unique.class_variable_set(:@@instances, Array.new) }
+      before(:each) { Unique.reset! }
 
     it "raises an error if a block is not passed" do
       expect{ Unique.next!(:t) }.to raise_error(Unique::NoArgumentsAllowed)


### PR DESCRIPTION
Allow users to clear our current object cache.  This is particularly useful when Unique is being used in combination with [RSpec](https://github.com/rspec/rspec) and [Faker](https://github.com/stympy/faker).
